### PR TITLE
rpc: uid/pass

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -415,7 +415,7 @@ func signer(c *cli.Context) error {
 
 		// start http server
 		httpEndpoint := fmt.Sprintf("%s:%d", c.String(utils.RPCListenAddrFlag.Name), c.Int(rpcPortFlag.Name))
-		listener, _, err := rpc.StartHTTPEndpoint(httpEndpoint, rpcAPI, []string{"account"}, cors, vhosts)
+		listener, _, err := rpc.StartHTTPEndpoint(httpEndpoint, rpcAPI, []string{"account"}, cors, vhosts, c.String(utils.RPCUserFlag.Name), c.String(utils.RPCPasswordFlag.Name))
 		if err != nil {
 			utils.Fatalf("Could not start RPC api: %v", err)
 		}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -127,6 +127,8 @@ var (
 
 	rpcFlags = []cli.Flag{
 		utils.RPCEnabledFlag,
+		utils.RPCUserFlag,
+		utils.RPCPasswordFlag,
 		utils.RPCListenAddrFlag,
 		utils.RPCPortFlag,
 		utils.RPCApiFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -145,6 +145,8 @@ var AppHelpFlagGroups = []flagGroup{
 		Name: "API AND CONSOLE",
 		Flags: []cli.Flag{
 			utils.RPCEnabledFlag,
+			utils.RPCUserFlag,
+			utils.RPCPasswordFlag,
 			utils.RPCListenAddrFlag,
 			utils.RPCPortFlag,
 			utils.RPCApiFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -377,6 +377,16 @@ var (
 		Name:  "rpc",
 		Usage: "Enable the HTTP-RPC server",
 	}
+	RPCUserFlag = cli.StringFlag{
+		Name:  "rpcuser",
+		Usage: "HTTP-RPC server user for basic authentication",
+		Value: "",
+	}
+	RPCPasswordFlag = cli.StringFlag{
+		Name:  "rpcpassword",
+		Usage: "HTTP-RPC server password for basic authentication",
+		Value: "",
+	}
 	RPCListenAddrFlag = cli.StringFlag{
 		Name:  "rpcaddr",
 		Usage: "HTTP-RPC server listening interface",
@@ -681,6 +691,12 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 		}
 	}
 
+	if ctx.GlobalIsSet(RPCUserFlag.Name) {
+		cfg.HTTPUser = ctx.GlobalString(RPCUserFlag.Name)
+	}
+	if ctx.GlobalIsSet(RPCPasswordFlag.Name) {
+		cfg.HTTPPassword = ctx.GlobalString(RPCPasswordFlag.Name)
+	}
 	if ctx.GlobalIsSet(RPCPortFlag.Name) {
 		cfg.HTTPPort = ctx.GlobalInt(RPCPortFlag.Name)
 	}

--- a/node/api.go
+++ b/node/api.go
@@ -132,6 +132,8 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 	if port == nil {
 		port = &api.node.config.HTTPPort
 	}
+	user := api.node.config.HTTPUser
+	password := api.node.config.HTTPPassword
 
 	allowedOrigins := api.node.config.HTTPCors
 	if cors != nil {
@@ -157,7 +159,7 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 		}
 	}
 
-	if err := api.node.startHTTP(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, allowedOrigins, allowedVHosts); err != nil {
+	if err := api.node.startHTTP(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, allowedOrigins, allowedVHosts, user, password); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/node/config.go
+++ b/node/config.go
@@ -95,6 +95,14 @@ type Config struct {
 	// field is empty, no HTTP API endpoint will be started.
 	HTTPHost string `toml:",omitempty"`
 
+	// HTTPUser is the username on which the HTTP RPC server uses for basic authentication. If
+	// this field is empty, no basic authentication is used.
+	HTTPUser string `toml:",omitempty"`
+
+	// HTTPPassword is the password on which the HTTP RPC server uses for basic authentication. If
+	// this field is empty, no basic authentication is used.
+	HTTPPassword string `toml:",omitempty"`
+
 	// HTTPPort is the TCP port number on which to start the HTTP RPC server. The
 	// default zero value is/ valid and will pick a port number randomly (useful
 	// for ephemeral nodes).

--- a/node/node.go
+++ b/node/node.go
@@ -263,7 +263,7 @@ func (n *Node) startRPC(services map[reflect.Type]Service) error {
 		n.stopInProc()
 		return err
 	}
-	if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPVirtualHosts); err != nil {
+	if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPVirtualHosts, n.config.HTTPUser, n.config.HTTPPassword); err != nil {
 		n.stopIPC()
 		n.stopInProc()
 		return err
@@ -331,16 +331,16 @@ func (n *Node) stopIPC() {
 }
 
 // startHTTP initializes and starts the HTTP RPC endpoint.
-func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors []string, vhosts []string) error {
+func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors []string, vhosts []string, user string, password string) error {
 	// Short circuit if the HTTP endpoint isn't being exposed
 	if endpoint == "" {
 		return nil
 	}
-	listener, handler, err := rpc.StartHTTPEndpoint(endpoint, apis, modules, cors, vhosts)
+	listener, handler, err := rpc.StartHTTPEndpoint(endpoint, apis, modules, cors, vhosts, user, password)
 	if err != nil {
 		return err
 	}
-	n.log.Info("HTTP endpoint opened", "url", fmt.Sprintf("http://%s", endpoint), "cors", strings.Join(cors, ","), "vhosts", strings.Join(vhosts, ","))
+	n.log.Info("HTTP endpoint opened", "url", fmt.Sprintf("http://%s", endpoint), "cors", strings.Join(cors, ","), "vhosts", strings.Join(vhosts, ","), "uid", user)
 	// All listeners booted successfully
 	n.httpEndpoint = endpoint
 	n.httpListener = listener

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -23,7 +23,7 @@ import (
 )
 
 // StartHTTPEndpoint starts the HTTP RPC endpoint, configured with cors/vhosts/modules
-func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []string, vhosts []string) (net.Listener, *Server, error) {
+func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []string, vhosts []string, user string, password string) (net.Listener, *Server, error) {
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
 	for _, module := range modules {
@@ -47,7 +47,7 @@ func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []str
 	if listener, err = net.Listen("tcp", endpoint); err != nil {
 		return nil, nil, err
 	}
-	go NewHTTPServer(cors, vhosts, handler).Serve(listener)
+	go NewHTTPServer(cors, vhosts, user, password, handler).Serve(listener)
 	return listener, handler, err
 }
 

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -19,6 +19,7 @@ package rpc
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/akroma-project/akroma/log"
 	"github.com/rs/cors"
 )
 
@@ -161,10 +163,15 @@ func (t *httpReadWriteNopCloser) Close() error {
 // NewHTTPServer creates a new HTTP RPC server around an API provider.
 //
 // Deprecated: Server implements http.Handler
-func NewHTTPServer(cors []string, vhosts []string, srv *Server) *http.Server {
+func NewHTTPServer(cors []string, vhosts []string, user string, password string, srv *Server) *http.Server {
 	// Wrap the CORS-handler within a host-handler
 	handler := newCorsHandler(srv, cors)
 	handler = newVHostHandler(vhosts, handler)
+
+	if user != "" && password != "" {
+		log.Info("HTTP endpoint is secured by basic authentication.")
+		handler = newBasicAuthHandler(user, password, handler)
+	}
 	return &http.Server{
 		Handler:      handler,
 		ReadTimeout:  5 * time.Second,
@@ -229,6 +236,20 @@ func newCorsHandler(srv *Server, allowedOrigins []string) http.Handler {
 		AllowedHeaders: []string{"*"},
 	})
 	return c.Handler(srv)
+}
+
+func newBasicAuthHandler(username string, password string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+
+		if !ok || subtle.ConstantTimeCompare([]byte(user), []byte(username)) != 1 || subtle.ConstantTimeCompare([]byte(pass), []byte(password)) != 1 {
+			w.Header().Set("WWW-Authenticate", `Basic realm="Please use the right user and password"`)
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 // virtualHostHandler is a handler which validates the Host-header of incoming requests.


### PR DESCRIPTION
This PR re-merges the code required to protect the API with a uid/pass.

The most recent push to `master` was a force-push that re-applied the Akroma changes to the most recent Ethereum code. From now on, we will merge in upstream changes on a weekly basis as to not drift too far away from the code base.