### PR TITLE
rpc/mn: re-apply the masternode flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     - os: osx
       go: 1.10.x
       script:
-        #- unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
+        - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
         - brew update
         - brew install caskroom/cask/brew-cask
         - brew cask install osxfuse

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -98,6 +98,7 @@ var (
 		utils.MaxPendingPeersFlag,
 		utils.EtherbaseFlag,
 		utils.GasPriceFlag,
+		utils.MasternodeFlag,
 		utils.MinerThreadsFlag,
 		utils.MiningEnabledFlag,
 		utils.TargetGasLimitFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -180,6 +180,12 @@ var AppHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
+		Name: "MASTER NODE",
+		Flags: []cli.Flag{
+			utils.MasternodeFlag,
+		},
+	},
+	{
 		Name: "MINER",
 		Flags: []cli.Flag{
 			utils.MiningEnabledFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -710,7 +710,7 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.GlobalIsSet(MasternodeFlag.Name) && cfg.HTTPHost == "" {
 		cfg.HTTPHost = "0.0.0.0"
-}
+	}
 	if ctx.GlobalIsSet(RPCApiFlag.Name) {
 		cfg.HTTPModules = splitAndTrim(ctx.GlobalString(RPCApiFlag.Name))
 	}
@@ -719,7 +719,7 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 		if len(cfg.HTTPCors) == 0 {
 			cfg.HTTPCors = splitAndTrim("*")
 		}
-}
+	}
 	if ctx.GlobalIsSet(RPCVirtualHostsFlag.Name) {
 		cfg.HTTPVirtualHosts = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -310,6 +310,11 @@ var (
 		Usage: "Number of trie node generations to keep in memory",
 		Value: int(state.MaxTrieCacheGen),
 	}
+	// Masternode settings
+	MasternodeFlag = cli.BoolFlag{
+		Name:  "masternode",
+		Usage: "Enable masternode",
+	}
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{
 		Name:  "mine",
@@ -687,9 +692,18 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(RPCCORSDomainFlag.Name) {
 		cfg.HTTPCors = splitAndTrim(ctx.GlobalString(RPCCORSDomainFlag.Name))
 	}
+	if ctx.GlobalIsSet(MasternodeFlag.Name) && cfg.HTTPHost == "" {
+		cfg.HTTPHost = "0.0.0.0"
+}
 	if ctx.GlobalIsSet(RPCApiFlag.Name) {
 		cfg.HTTPModules = splitAndTrim(ctx.GlobalString(RPCApiFlag.Name))
 	}
+	if ctx.GlobalIsSet(MasternodeFlag.Name) {
+		cfg.HTTPModules = append(cfg.HTTPModules, "net")
+		if len(cfg.HTTPCors) == 0 {
+			cfg.HTTPCors = splitAndTrim("*")
+		}
+}
 	if ctx.GlobalIsSet(RPCVirtualHostsFlag.Name) {
 		cfg.HTTPVirtualHosts = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
 	}


### PR DESCRIPTION
This PR re-applies the logic to enable the masternode flag. This logic is being re-applied now that we are at the most recent source code version of the Ethereum codebase.