### PR TITLE
pass parmas for tx filter

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -308,7 +308,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 		}
 	}()
 	// Start auxiliary services if enabled
-	log.Info("Transaction Indexing", "AddrTxIndexFlax", ctx.GlobalBool(utils.AddrTxIndexFlag.Name), "AddrTxIndexAutoBuildFlag", ctx.GlobalBool(utils.AddrTxIndexAutoBuildFlag.Name))
+	log.Info("Transaction Indexing", "AddrTxIndexFlag", ctx.GlobalBool(utils.AddrTxIndexFlag.Name), "AddrTxIndexAutoBuildFlag", ctx.GlobalBool(utils.AddrTxIndexAutoBuildFlag.Name))
 	if ctx.GlobalBool(utils.AddrTxIndexFlag.Name) && ctx.GlobalBool(utils.AddrTxIndexAutoBuildFlag.Name) {
 		var ethereum *eth.Ethereum
 		if err := stack.Service(&ethereum); err != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -528,7 +528,7 @@ func (api *PublicBlockChainAPI) GetTransactionsByAddress(address common.Address,
 
 // GetTransactionCountByAddress
 // Returns total transactions
-func (api *PublicBlockChainAPI) GetTransactionCountByAddress(address common.Address, blockStartN uint64, blockEndN rpc.BlockNumber, toOrFrom string, txKindOf string, reverse bool) (hexutil.Uint64, error) {
+func (api *PublicBlockChainAPI) GetTransactionCountByAddress(address common.Address, blockStartN uint64, blockEndN rpc.BlockNumber, toOrFrom string, txKindOf string) (hexutil.Uint64, error) {
 	log.Info("RPC call: eth_getTransactionCountByAddress", "address", address, "start", blockStartN, "end", blockEndN, "toOrFrom", toOrFrom, "kind", txKindOf)
 
 	atxi := api.b.Atxi()
@@ -546,7 +546,7 @@ func (api *PublicBlockChainAPI) GetTransactionCountByAddress(address common.Addr
 	if blockEndN == rpc.LatestBlockNumber || blockEndN == rpc.PendingBlockNumber {
 		blockEndN = 0
 	}
-	txs, err := core.GetAddrTxs(atxi.Db, address, blockStartN, uint64(blockEndN.Int64()), "", "", -1, -1, false)
+	txs, err := core.GetAddrTxs(atxi.Db, address, blockStartN, uint64(blockEndN.Int64()), toOrFrom, txKindOf, -1, -1, false)
 	if err != nil {
 		return hexutil.Uint64(uint64(0)), err
 	}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -440,8 +440,8 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'getTransactionCountByAddress',
 			call: 'eth_getTransactionCountByAddress',
-			params: 6,
-			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null, null, null, null, null]
+			params: 5,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null, null, null, null]
 		}),
 		new web3._extend.Method({
 			name: 'buildATXI',


### PR DESCRIPTION
issue #64 

- pass the params down to the correct method.
- fix spelling
- remove unused  "reverse" param on count.