### PR TITLE
feat(blockchain): prevent reorg greater then 64 blocks)

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1550,7 +1550,7 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	if len(oldChain) > 0 && len(newChain) > 0 {
 		logFn := log.Debug
 		if len(oldChain) > 63 {
-			logFn = log.Warn
+			return fmt.Errorf("Chain is too long for reorg")
 		}
 		logFn("Chain split detected", "number", commonBlock.Number(), "hash", commonBlock.Hash(),
 			"drop", len(oldChain), "dropfrom", oldChain[0].Hash(), "add", len(newChain), "addfrom", newChain[0].Hash())

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1548,11 +1548,10 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	}
 	// Ensure the user sees large reorgs
 	if len(oldChain) > 0 && len(newChain) > 0 {
-		logFn := log.Debug
-		if len(oldChain) > 63 {
+		if len(oldChain) > 64 {
 			return fmt.Errorf("Chain is too long for reorg")
 		}
-		logFn("Chain split detected", "number", commonBlock.Number(), "hash", commonBlock.Hash(),
+		log.Debug("Chain split detected", "number", commonBlock.Number(), "hash", commonBlock.Hash(),
 			"drop", len(oldChain), "dropfrom", oldChain[0].Hash(), "add", len(newChain), "addfrom", newChain[0].Hash())
 	} else {
 		log.Error("Impossible reorg, please file an issue", "oldnum", oldBlock.Number(), "oldhash", oldBlock.Hash(), "newnum", newBlock.Number(), "newhash", newBlock.Hash())

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -374,8 +374,8 @@ func TestReorgShortBlocks(t *testing.T)  { testReorgShort(t, true) }
 func testReorgShort(t *testing.T, full bool) {
 	// Create a long easy chain vs. a short heavy one. Due to difficulty adjustment
 	// we need a fairly long chain of blocks with different difficulties for a short
-	// one to become heavyer than a long one. The 96 is an empirical value.
-	easy := make([]int64, 96)
+	// one to become heavyer than a long one. The 64 is an empirical value.
+	easy := make([]int64, 64)
 	for i := 0; i < len(easy); i++ {
 		easy[i] = 60
 	}


### PR DESCRIPTION
This PR introduces a rolling checkpoint 64 blocks from tip.

The checkpoint should be included in all Akroma clients. Once this PR is merged, all exchanges and pools and bootnodes are encouraged to update to the latest version of Akroma.

This is NOT a hard-fork, but only clients that have the latest version will be protected from deep reorgs.